### PR TITLE
Fix browser-based tests on Mac

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,12 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true
-    },
     "accepts": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
@@ -56,12 +50,6 @@
           "dev": true
         }
       }
-    },
-    "adm-zip": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.2.1.tgz",
-      "integrity": "sha1-6AHO3rW9mk6Y1pnFwPQjnicx3L8=",
-      "dev": true
     },
     "ajv": {
       "version": "5.2.3",
@@ -200,13 +188,6 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
-    "asn1": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-      "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc=",
-      "dev": true,
-      "optional": true
-    },
     "asn1.js": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
@@ -224,13 +205,6 @@
       "requires": {
         "util": "0.10.3"
       }
-    },
-    "assert-plus": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-      "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
-      "dev": true,
-      "optional": true
     },
     "assertion-error": {
       "version": "1.0.2",
@@ -269,13 +243,6 @@
         "postcss": "5.2.17",
         "postcss-value-parser": "3.3.0"
       }
-    },
-    "aws-sign2": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
-      "integrity": "sha1-xXED96F/wDfwLXwuZLYC6iI/fWM=",
-      "dev": true,
-      "optional": true
     },
     "aws4": {
       "version": "1.6.0",
@@ -576,15 +543,6 @@
         "dns-txt": "2.0.2",
         "multicast-dns": "6.1.1",
         "multicast-dns-service-types": "1.1.0"
-      }
-    },
-    "boom": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
-      "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
-      "dev": true,
-      "requires": {
-        "hoek": "0.9.1"
       }
     },
     "bootstrap": {
@@ -978,16 +936,6 @@
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
       "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
     },
-    "combined-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-      "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "delayed-stream": "0.0.5"
-      }
-    },
     "commander": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
@@ -1046,24 +994,6 @@
         "inherits": "2.0.3",
         "readable-stream": "2.3.3",
         "typedarray": "0.0.6"
-      }
-    },
-    "config-chain": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
-      "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
-      "dev": true,
-      "requires": {
-        "ini": "1.3.4",
-        "proto-list": "1.2.4"
-      },
-      "dependencies": {
-        "ini": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
-          "dev": true
-        }
       }
     },
     "connect-history-api-fallback": {
@@ -1155,16 +1085,6 @@
         "lru-cache": "4.1.1",
         "shebang-command": "1.2.0",
         "which": "1.3.0"
-      }
-    },
-    "cryptiles": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
-      "integrity": "sha1-7ZH/HxetE9N0gohZT4pIoNJvMlw=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "boom": "0.4.2"
       }
     },
     "crypto-browserify": {
@@ -1273,13 +1193,6 @@
         "source-map": "0.5.7"
       }
     },
-    "ctype": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
-      "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8=",
-      "dev": true,
-      "optional": true
-    },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -1383,13 +1296,6 @@
         "pinkie-promise": "2.0.1",
         "rimraf": "2.6.2"
       }
-    },
-    "delayed-stream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
-      "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8=",
-      "dev": true,
-      "optional": true
     },
     "depd": {
       "version": "1.1.1",
@@ -2866,9 +2772,9 @@
       }
     },
     "file-loader": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-1.0.0.tgz",
-      "integrity": "sha512-evlTRyNUDiFmlMW2gGepbzx7lB1V1BsElqtIwhq4aPUnvTFvzri8Ua4EaJ+gfRGaUQLdP7joSllvkZBCflho2w==",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-0.11.2.tgz",
+      "integrity": "sha512-N+uhF3mswIFeziHQjGScJ/yHXYt3DiLBeC+9vWW+WjUBiClMSOlV1YrXQi+7KM2aA3Rn4Bybgv+uXFQbfkzpvg==",
       "requires": {
         "loader-utils": "1.1.0"
       }
@@ -2959,40 +2865,6 @@
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
       "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
       "dev": true
-    },
-    "forever-agent": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
-      "integrity": "sha1-bQ4JxJIflKJ/Y9O0nF/v8epMUTA=",
-      "dev": true
-    },
-    "form-data": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
-      "integrity": "sha1-kavXiKupcCsaq/qLwBAxoqyeOxI=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "async": "0.9.2",
-        "combined-stream": "0.0.7",
-        "mime": "1.2.11"
-      },
-      "dependencies": {
-        "async": {
-          "version": "0.9.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
-          "dev": true,
-          "optional": true
-        },
-        "mime": {
-          "version": "1.2.11",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
-          "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA=",
-          "dev": true,
-          "optional": true
-        }
-      }
     },
     "forwarded": {
       "version": "0.1.2",
@@ -4052,19 +3924,6 @@
         "pinkie-promise": "2.0.1"
       }
     },
-    "hawk": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
-      "integrity": "sha1-uQuxaYByhUEdp//LjdJZhQLTtS0=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "boom": "0.4.2",
-        "cryptiles": "0.2.2",
-        "hoek": "0.9.1",
-        "sntp": "0.2.4"
-      }
-    },
     "he": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
@@ -4080,12 +3939,6 @@
         "minimalistic-assert": "1.0.0",
         "minimalistic-crypto-utils": "1.0.1"
       }
-    },
-    "hoek": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
-      "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU=",
-      "dev": true
     },
     "hosted-git-info": {
       "version": "2.5.0",
@@ -4184,18 +4037,6 @@
             "is-extglob": "2.1.1"
           }
         }
-      }
-    },
-    "http-signature": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-      "integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "asn1": "0.1.11",
-        "assert-plus": "0.1.5",
-        "ctype": "0.5.3"
       }
     },
     "https-browserify": {
@@ -4315,12 +4156,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-    },
-    "ini": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.1.0.tgz",
-      "integrity": "sha1-ToCMLOFExsF4iRjgNNZ5e8bPYoE=",
-      "dev": true
     },
     "inquirer": {
       "version": "3.3.0",
@@ -4799,12 +4634,6 @@
           "dev": true
         }
       }
-    },
-    "kew": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/kew/-/kew-0.1.7.tgz",
-      "integrity": "sha1-CjKoF/8amzsSuMm6z0vE1nmvjnI=",
-      "dev": true
     },
     "kind-of": {
       "version": "3.2.2",
@@ -5518,65 +5347,10 @@
         }
       }
     },
-    "mocha-phantomjs": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/mocha-phantomjs/-/mocha-phantomjs-4.1.0.tgz",
-      "integrity": "sha1-x14WYS4aavCtjSgeOi/vSdVeUFs=",
-      "dev": true,
-      "requires": {
-        "commander": "2.9.0",
-        "mocha-phantomjs-core": "1.3.1",
-        "phantomjs": "1.9.7-15"
-      },
-      "dependencies": {
-        "mkdirp": {
-          "version": "0.3.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
-          "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=",
-          "dev": true
-        },
-        "phantomjs": {
-          "version": "1.9.7-15",
-          "resolved": "https://registry.npmjs.org/phantomjs/-/phantomjs-1.9.7-15.tgz",
-          "integrity": "sha1-Czp85jBIaoO+kf9Ogy7uIOlxEVs=",
-          "dev": true,
-          "requires": {
-            "adm-zip": "0.2.1",
-            "kew": "0.1.7",
-            "mkdirp": "0.3.5",
-            "ncp": "0.4.2",
-            "npmconf": "0.0.24",
-            "progress": "1.1.8",
-            "request": "2.36.0",
-            "request-progress": "0.3.1",
-            "rimraf": "2.2.8",
-            "which": "1.0.9"
-          }
-        },
-        "progress": {
-          "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-          "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
-          "dev": true
-        },
-        "rimraf": {
-          "version": "2.2.8",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
-          "dev": true
-        },
-        "which": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
-          "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8=",
-          "dev": true
-        }
-      }
-    },
     "mocha-phantomjs-core": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/mocha-phantomjs-core/-/mocha-phantomjs-core-1.3.1.tgz",
-      "integrity": "sha1-WGU4yNcfqN6QxBpGrMBIHB+4Phg=",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mocha-phantomjs-core/-/mocha-phantomjs-core-2.1.2.tgz",
+      "integrity": "sha1-hszADa9OtwE3RarsL1SZe9ayS70=",
       "dev": true
     },
     "ms": {
@@ -5617,12 +5391,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-      "dev": true
-    },
-    "ncp": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
-      "integrity": "sha1-q8xsvT7C7Spyn/bnwfqPAXhKhXQ=",
       "dev": true
     },
     "negotiator": {
@@ -5674,21 +5442,6 @@
         }
       }
     },
-    "node-uuid": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
-      "dev": true
-    },
-    "nopt": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
-      "integrity": "sha1-KqCbfRdoSHs7ianFqlIzW/8Lrqc=",
-      "dev": true,
-      "requires": {
-        "abbrev": "1.1.1"
-      }
-    },
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -5732,48 +5485,6 @@
         "path-key": "2.0.1"
       }
     },
-    "npmconf": {
-      "version": "0.0.24",
-      "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-0.0.24.tgz",
-      "integrity": "sha1-t4h1sIjMw8Cvo+zrPOMkSxtSOQw=",
-      "dev": true,
-      "requires": {
-        "config-chain": "1.1.11",
-        "inherits": "1.0.2",
-        "ini": "1.1.0",
-        "mkdirp": "0.3.5",
-        "nopt": "2.2.1",
-        "once": "1.1.1",
-        "osenv": "0.0.3",
-        "semver": "1.1.4"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
-          "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.3.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
-          "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=",
-          "dev": true
-        },
-        "once": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz",
-          "integrity": "sha1-nbV0kzzLCMOnYU0VQDLAnqbzOec=",
-          "dev": true
-        },
-        "semver": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-1.1.4.tgz",
-          "integrity": "sha1-LlpOcrqwNHLMl/cnU7RQiRLvVUA=",
-          "dev": true
-        }
-      }
-    },
     "num2fraction": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
@@ -5783,13 +5494,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-    },
-    "oauth-sign": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz",
-      "integrity": "sha1-y1QPk7srIqfVlBaRoojWDo6pOG4=",
-      "dev": true,
-      "optional": true
     },
     "object-assign": {
       "version": "4.1.1",
@@ -5937,12 +5641,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
-    },
-    "osenv": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz",
-      "integrity": "sha1-zWrY3bKQkVrZ4idlV2Al1BHynLY=",
       "dev": true
     },
     "p-finally": {
@@ -6869,12 +6567,6 @@
       "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
       "dev": true
     },
-    "proto-list": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-      "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
-      "dev": true
-    },
     "proxy-addr": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz",
@@ -6916,12 +6608,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
       "integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE="
-    },
-    "qs": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz",
-      "integrity": "sha1-bgFQmP9RlouKPIGQAdXyyJvEsQc=",
-      "dev": true
     },
     "query-string": {
       "version": "4.3.4",
@@ -7169,43 +6855,6 @@
       "dev": true,
       "requires": {
         "is-finite": "1.0.2"
-      }
-    },
-    "request": {
-      "version": "2.36.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.36.0.tgz",
-      "integrity": "sha1-KMbAQmLHuf/dIbklU3RRfubZQ/U=",
-      "dev": true,
-      "requires": {
-        "aws-sign2": "0.5.0",
-        "forever-agent": "0.5.2",
-        "form-data": "0.1.4",
-        "hawk": "1.0.0",
-        "http-signature": "0.10.1",
-        "json-stringify-safe": "5.0.1",
-        "mime": "1.2.11",
-        "node-uuid": "1.4.8",
-        "oauth-sign": "0.3.0",
-        "qs": "0.6.6",
-        "tough-cookie": "2.3.3",
-        "tunnel-agent": "0.4.3"
-      },
-      "dependencies": {
-        "mime": {
-          "version": "1.2.11",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
-          "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA=",
-          "dev": true
-        }
-      }
-    },
-    "request-progress": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
-      "integrity": "sha1-ByHBBdipasayzossia4tXs/Pazo=",
-      "dev": true,
-      "requires": {
-        "throttleit": "0.0.2"
       }
     },
     "require-directory": {
@@ -7512,16 +7161,6 @@
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         }
-      }
-    },
-    "sntp": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
-      "integrity": "sha1-+4hfGLDzqtGJ+CSGJTa87ux1CQA=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "hoek": "0.9.1"
       }
     },
     "sockjs": {
@@ -7893,12 +7532,6 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
-    "throttleit": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
-      "integrity": "sha1-z+34jmDADdlpe2H90qg0OptoDq8=",
-      "dev": true
-    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -7970,13 +7603,6 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
-    },
-    "tunnel-agent": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-      "dev": true,
-      "optional": true
     },
     "tweetnacl": {
       "version": "0.14.5",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "serve": "webpack-dev-server --hot --inline --open",
     "test": "npm run test-unit && npm run test-client",
     "test-unit": "mocha test/model-test.js",
-    "test-client": "mocha-phantomjs -R nyan dist/view-test.html",
+    "test-client": "phantomjs ./node_modules/mocha-phantomjs-core/mocha-phantomjs-core.js dist/view-test.html",
     "build": "webpack && webpack --config test/test.webpack.config.js"
   },
   "repository": {
@@ -19,7 +19,6 @@
     "phantomjs",
     "mocha",
     "chai",
-    "phantomjs",
     "jquery",
     "client",
     "ctl"
@@ -49,10 +48,10 @@
     "eslint-plugin-no-unsafe-innerhtml": "^1.0.16",
     "eslint-plugin-security": "^1.4.0",
     "loglevel": "^1.4.1",
-    "mocha": "^3.4.2",
-    "mocha-phantomjs": "^4.1.0",
-    "phantomjs-prebuilt": "^2.1.14",
-    "webpack-dev-server": "^2.4.5"
+    "mocha": "^3.5.3",
+    "mocha-phantomjs-core": "^2.1.2",
+    "phantomjs-prebuilt": "^2.1.15",
+    "webpack-dev-server": "^2.9.1"
   },
   "dependencies": {
     "backbone": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "serve": "webpack-dev-server --hot --inline --open",
     "test": "npm run test-unit && npm run test-client",
     "test-unit": "mocha test/model-test.js",
-    "test-client": "phantomjs ./node_modules/mocha-phantomjs-core/mocha-phantomjs-core.js dist/view-test.html",
+    "test-client": "./node_modules/phantomjs-prebuilt/bin/phantomjs ./node_modules/mocha-phantomjs-core/mocha-phantomjs-core.js dist/view-test.html",
     "build": "webpack && webpack --config test/test.webpack.config.js"
   },
   "repository": {


### PR DESCRIPTION
When running mocha-phantomjs (or plain PhantomJS for that matter) on the new Mac OS Sierra, it fails with the following error:

`phantomjs terminated with signal SIGSEGV`

This issue describes the problem and suggests switching to mocha-phantomjs-core to resolve. This worked for me, and continues to pass on Travis.CI
https://github.com/nathanboktae/mocha-phantomjs/issues/245