### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "file-loader": "^1.1.11",
     "style-loader": "^0.21.0",
     "webpack-dev-server": "^3.0.0",
-    "webpack-cli": "~3.0.2"
+    "webpack-cli": "3.0.2"
   },
   "dependencies": {
     "backbone": "1.3.3",


### PR DESCRIPTION
Greenkeeper sends a pr for every dependency update only if the dependency is "pinned", i.e. does not have a modifier like `~`. I want to test the greenkeeper-lockfile mechanism, so am removing the `~` on the webpack-cli dependency.