### PR TITLE
Fix image loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "file-loader": "^5.0.1",
     "style-loader": "^1.0.0",
     "webpack-dev-server": "^3.0.0",
-    "webpack-cli": "~3.3.4"
+    "webpack-cli": "~3.0.0"
   },
   "dependencies": {
     "backbone": "1.4.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,13 +23,23 @@ module.exports = {
             {
                 test: /\.(png|svg|jpg|gif)$/,
                 use: [
-                    'file-loader'
+                    {
+                        loader: 'file-loader',
+                        options: {
+                            esModule: false
+                        }
+                    }
                 ]
             },
             {
                 test: /\.(woff|woff2|eot|ttf|otf)$/,
                 use: [
-                    'file-loader'
+                    {
+                        loader: 'file-loader',
+                        options: {
+                            esModule: false
+                        }
+                    }
                 ]
             }
         ]


### PR DESCRIPTION
file-loader 5.0.0 turned on the option to generate ES modules by default.

Turning this option off for the moment until we have more time to investigate.